### PR TITLE
Add DeploymentTracker CustomResourceDefinition and configure RBAC for deployment-tracker service account.

### DIFF
--- a/chart/k8s-deploy-watcher/templates/serviceaccount.yaml
+++ b/chart/k8s-deploy-watcher/templates/serviceaccount.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ .Values.serviceAccount.name | default "deployment-tracker" }}
+  namespace: {{ .Values.serviceAccount.namespace | default "default" }}
+  labels:
+    app: {{ .Chart.Name }}

--- a/config/crd/deployment_tracker.yaml
+++ b/config/crd/deployment_tracker.yaml
@@ -1,9 +1,9 @@
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  name: deploymenttrackers.ddukbg
+  name: deploymenttrackers.ddukbg.k8s
 spec:
-  group: ddukbg
+  group: ddukbg.k8s
   names:
     kind: DeploymentTracker
     plural: deploymenttrackers
@@ -15,7 +15,7 @@ spec:
   - name: v1alpha1
     served: true
     storage: true
-    additionalPrinterColumns:  # 추가: kubectl get 명령어에서 보이는 컬럼
+    additionalPrinterColumns:
     - name: Ready
       type: boolean
       jsonPath: .status.ready
@@ -25,11 +25,11 @@ spec:
     schema:
       openAPIV3Schema:
         type: object
-        required: ["spec"]  # spec을 필수값으로 지정
+        required: ["spec"]
         properties:
           spec:
             type: object
-            required: ["deploymentName"]  # deploymentName을 필수값으로 지정
+            required: ["deploymentName"]
             properties:
               deploymentName:
                 type: string
@@ -40,10 +40,10 @@ spec:
                 properties:
                   slack:
                     type: string
-                    pattern: '^https://hooks\.slack\.com/services/.*$'  # Slack URL 형식 검증
+                    pattern: '^https://hooks\.slack\.com/services/.*$'
                   email:
                     type: string
-                    pattern: '^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$'  # 이메일 형식 검증
+                    pattern: '^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$'
                   retryCount:
                     type: integer
                     minimum: 0
@@ -65,4 +65,4 @@ spec:
               message:
                 type: string
     subresources:
-      status: {}  # status 서브리소스 활성화
+      status: {}

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -1,0 +1,39 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: k8s-deploy-watcher
+  namespace: default
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: k8s-deploy-watcher
+  template:
+    metadata:
+      labels:
+        app: k8s-deploy-watcher
+    spec:
+      serviceAccountName: deployment-tracker
+      containers:
+      - name: manager
+        image: ddukbg/k8s-deploy-watcher:latest
+        ports:
+        - containerPort: 8080
+          name: metrics
+        - containerPort: 8081
+          name: health
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: 8081
+        readinessProbe:
+          httpGet:
+            path: /readyz
+            port: 8081
+        resources:
+          limits:
+            cpu: 500m
+            memory: 256Mi
+          requests:
+            cpu: 200m
+            memory: 128Mi

--- a/config/manager/serviceaccount.yaml
+++ b/config/manager/serviceaccount.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: deployment-tracker
+  namespace: default

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -3,7 +3,7 @@ kind: ClusterRole
 metadata:
   name: deployment-tracker-role
 rules:
-- apiGroups: ["ddukbg"]
+- apiGroups: ["ddukbg.k8s"]
   resources: ["deploymenttrackers"]
   verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
 - apiGroups: ["apps"]
@@ -12,6 +12,6 @@ rules:
 - apiGroups: [""]
   resources: ["events"]
   verbs: ["create"]
-- apiGroups: ["ddukbg"]
+- apiGroups: ["ddukbg.k8s"]
   resources: ["deploymenttrackers/status"]
   verbs: ["get", "update", "patch"]


### PR DESCRIPTION

#### **English:**
**Add DeploymentTracker CRD and RBAC Configurations**

- Introduced `deploymenttracker-crd.yaml` to define the DeploymentTracker custom resource.
- Configured `Role` and `RoleBinding` to grant necessary permissions to the `deployment-tracker` service account.
- Updated Helm templates to include the new CRD and RBAC resources.

#### **Korean:**
**DeploymentTracker CRD 및 RBAC 구성 추가**

- DeploymentTracker 커스텀 리소스를 정의하기 위해 `deploymenttracker-crd.yaml` 파일을 추가했습니다.
- `deployment-tracker` 서비스 어카운트에 필요한 권한을 부여하기 위해 `Role` 및 `RoleBinding`을 설정했습니다.
- 새로운 CRD 및 RBAC 리소스를 포함하도록 Helm 템플릿을 업데이트했습니다.

